### PR TITLE
Update Importlib_metadata to 4.8.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,4 @@
+build_parameters:
+  - "--suppress-variables"
+  - "--error-overlinking"
+  - "--error-overdepending"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,6 +50,8 @@ about:
   license_family: APACHE
   license_file: LICENSE
   summary: A library to access the metadata for a Python package
+  dev_url: https://github.com/python/importlib_metadata
+  doc_url: https://importlib-metadata.readthedocs.io/en/latest
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.10.0" %}
+{% set version = "4.8.1" %}
 
 package:
   name: importlib-metadata
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/i/importlib_metadata/importlib_metadata-{{ version }}.tar.gz
-  sha256: c9db46394197244adf2f0b08ec5bc3cf16757e9590b02af1fca085c16c0d600a
+  sha256: f284b3e11256ad1e5d03ab86bb2ccd6f5339688ff17a4d797a0fe7df326f23b1
 
 build:
   number: 0


### PR DESCRIPTION
1. check the upstream 

    https://github.com/python/importlib_metadata/blob/main/CHANGES.rst


    #348: Restored support for `EntryPoint` access by item, deprecating support in the process. Users are advised to use direct member access instead of item-based access

    There is one potential breaking change in the change log related to `EntryPoint`, however there is an alternative provided by using direct member access. 

    The rest of the issues are fixes and updates

2. check the pinnings
3. added dev_url: https://github.com/python/importlib_metadata
4. added doc_url: https://importlib-metadata.readthedocs.io/en/latest
5. verify that pip is checked
6. verify the test section 
7. additional tests

   The following command was used for testing `conda-build importlib_metadata-feedstock --test`
   The result was the following `All tests passed`

8. additional research

    There were no open issues on conda forge
    https://github.com/conda-forge/importlib_metadata-feedstock/issues

  Based on our results we can conclude that it is safe to update to version 4.8.1
