### PR TITLE
importlib_metadata 4.8.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,20 +10,20 @@ source:
 
 build:
   number: 0
+  skip: True # [py<36]
 
 outputs:
   - name: importlib-metadata
     script: build_base.sh
     requirements:
-      build:
-        - python                                 # [build_platform != target_platform]
-        #- cross-python_{{ target_platform }}    # [build_platform != target_platform]
       host:
         - python
         - pip
-        - setuptools_scm
+        - setuptools >=56
+        - setuptools_scm >=3.4.1,!=6.1.0
+        - toml
       run:
-        - python
+        - python >=3.6
         - typing_extensions >=3.6.4  # [py<38]
         - zipp >=0.5
     test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "4.8.1" %}
+{% set version = "4.8.2" %}
 
 package:
   name: importlib-metadata
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/i/importlib_metadata/importlib_metadata-{{ version }}.tar.gz
-  sha256: f284b3e11256ad1e5d03ab86bb2ccd6f5339688ff17a4d797a0fe7df326f23b1
+  sha256: 75bdec14c397f528724c1bfd9709d660b33a4d2e77387a3358f20b848bb5e5fb
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,7 +49,7 @@ about:
   license: Apache-2.0
   license_family: APACHE
   license_file: LICENSE
-  summary: A library to access the metadata for a Python package
+  summary: A library to access the metadata for a Python package.
   dev_url: https://github.com/python/importlib_metadata
   doc_url: https://importlib-metadata.readthedocs.io/en/latest
 


### PR DESCRIPTION
Update importlib_metadata to 4.8.2

Version change: bump version number from 4.8.1 to 4.8.2
Bug Tracker: new open issues https://github.com/python/importlib_metadata/issues
Upstream license:  License file:  https://github.com/python/importlib_metadata/blob/master/LICENSE
Upstream Changelog: https://github.com/python/importlib_metadata/blob/main/CHANGES.rst
Upstream setup.cfg:  https://github.com/python/importlib_metadata/blob/v4.8.2/setup.cfg
Upstream pyproject.toml:  https://github.com/python/importlib_metadata/blob/v4.8.2/pyproject.toml

The package importlib_metadata is mentioned inside the packages:
argcomplete | datasets | huggingface_hub | importlib_resources | jsonpickle | jsonschema | keyring | kombu | path | pep517 | pluggy | py7zr | pyppmd | twine | zipp |

Actions:
1. Skip py<36
2. Update dependencies in host

Result:
- all-succeeded
