### PR TITLE
importlib_metadata 4.11.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "4.8.2" %}
+{% set version = "4.11.3" %}
 
 package:
   name: importlib-metadata
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/i/importlib_metadata/importlib_metadata-{{ version }}.tar.gz
-  sha256: 75bdec14c397f528724c1bfd9709d660b33a4d2e77387a3358f20b848bb5e5fb
+  sha256: ea4c597ebf37142f827b8f39299579e31685c31d3a438b59f469406afd0f2539
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,8 +10,7 @@ source:
 
 build:
   number: 0
-  # trigger: 1
-  skip: True # [py<36]
+  skip: True # [py<37]
 
 outputs:
   - name: importlib-metadata
@@ -24,7 +23,7 @@ outputs:
         - setuptools_scm >=3.4.1,!=6.1.0
         - toml
       run:
-        - python >=3.6
+        - python >=3.7
         - typing_extensions >=3.6.4  # [py<38]
         - zipp >=0.5
     test:


### PR DESCRIPTION
Update importlib_metadata to 4.11.3

_importlib_metadata  4.8.2 hasn't python 3.10 support on ppc64le_

Version change: bump version number from 4.8.2 to 4.11.3
Bug Tracker: new open issues https://github.com/python/importlib_metadata/issues
Upstream license: License file: https://github.com/python/importlib_metadata/blob/master/LICENSE
Upstream Changelog: https://github.com/python/importlib_metadata/blob/main/CHANGES.rst
Upstream setup.cfg: https://github.com/python/importlib_metadata/blob/v4.11.3/setup.cfg
Upstream pyproject.toml: https://github.com/python/importlib_metadata/blob/v4.11.3/pyproject.toml

The package importlib_metadata is mentioned inside the packages:
argcomplete | datasets | huggingface_hub | importlib_resources | jsonpickle | jsonschema | keyring | kombu | path | pep517 | pluggy | py7zr | pyppmd | twine | zipp |

Actions:
1. 

all-succeeded
