### PR TITLE
importlib-metadata 9.0.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,20 +1,20 @@
 {% set name_norm = "importlib_metadata" %}
 {% set name_alt = name_norm.replace('_', '-') %}
-{% set version = "8.7.1" %}
+{% set version = "9.0.0" %}
 
+# making this package multi output for the sole purpose of allowing both '-' and '_' naming conventions
 package:
   name: {{ name_norm }}-suite
   version: {{ version }}
 
 source:
   url: https://pypi.org/packages/source/{{ name_norm[0] }}/{{ name_norm }}/{{ name_norm }}-{{ version }}.tar.gz
-  sha256: 49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb
+  sha256: a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc
 
 build:
   number: 0
   skip: true  # [py<39]
 
-# making this package multi output for the sole purpose of allowing both '-' and '_' naming conventions
 outputs:
   - name: {{ name_alt }}
     script: build_base.sh  # [unix]
@@ -47,6 +47,9 @@ outputs:
     requirements:
       run:
         - {{ pin_subpackage('importlib-metadata', max_pin="x.x.x") }}
+        - python
+      host:
+        - python
     test:
       requires:
         - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [py<39]
+  skip: true  # [py<310]
 
 outputs:
   - name: {{ name_alt }}
@@ -35,21 +35,20 @@ outputs:
       requires:
         - pip
         - pytest >=6,!=8.1.*
-        - jaraco.test >=5.4
+        - packaging
         - pyfakefs
       commands:
         - pip check
         - python -c "from importlib.metadata import version; assert(version('{{ name_norm }}')=='{{ version }}')"
         - pytest -v tests
+      imports:
+        - {{ name_norm }}
   - name: {{ name_norm }}
     build:
       noarch: generic
     requirements:
       run:
         - {{ pin_subpackage('importlib-metadata', max_pin="x.x.x") }}
-        - python
-      host:
-        - python
     test:
       requires:
         - pip


### PR DESCRIPTION
## Links
- Jira: https://anaconda.atlassian.net/browse/PKG-16496
- Project: https://github.com/python/importlib_metadata
- conda-forge recipe: https://github.com/conda-forge/importlib_metadata-feedstock
- PyPI: https://pypi.org/project/importlib_metadata/9.0.0
- PyPI Inspector: https://inspector.pypi.io/project/importlib_metadata/9.0.0

Bump importlib_metadata to 9.0.0.

## Notes
- `requires-python` moved to `>=3.10`; recipe skip condition updated from `py<39` to `py<310`.
- Swapped test dep `jaraco.test` for `packaging` to match upstream's v9.0.0 test suite (jaraco.test is no longer imported anywhere; packaging is used directly in test_integration.py).
- `pyproject.toml`'s new build requirement `coherent.licensed` (a release-time license-file-injection plugin) is unavailable in the `main` channel; not added to `host` since it's not needed to build from the published sdist. Flagging in case a separate PKG ticket is wanted.
- Removed an erroneous `host`/`run` python addition the automation bot introduced on the `importlib_metadata` shim output — it wasn't present in 8.7.1, isn't needed, and was itself the cause of the bot's unresolved `missing_python_build_tool` lint error.